### PR TITLE
Normalize GameplayGraph namespaces

### DIFF
--- a/Assets/Plugins/GameplayGraph/Runtime/Core/ContainerPropertyAttribute.cs
+++ b/Assets/Plugins/GameplayGraph/Runtime/Core/ContainerPropertyAttribute.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Agent.Core.Gameplay
+namespace GameplayGraph
 {
     [AttributeUsage(AttributeTargets.Property)]
     public class ContainerPropertyAttribute : Attribute

--- a/Assets/Plugins/GameplayGraph/Runtime/Core/ItemContainer.cs
+++ b/Assets/Plugins/GameplayGraph/Runtime/Core/ItemContainer.cs
@@ -1,4 +1,4 @@
-namespace Agent.Core.Gameplay
+namespace GameplayGraph
 {
     /// <summary>
     /// Simple implementation of <see cref="ListContainer{T}"/> representing a list of items.

--- a/Assets/Plugins/GameplayGraph/Runtime/Core/ListContainer.cs
+++ b/Assets/Plugins/GameplayGraph/Runtime/Core/ListContainer.cs
@@ -1,7 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 
-namespace Agent.Core.Gameplay
+namespace GameplayGraph
 {
     /// <summary>
     /// Container backed by a dynamic list of values. Each item is exposed via a

--- a/Assets/Plugins/GameplayGraph/Runtime/Core/ListSlotDescriptorTemplate.cs
+++ b/Assets/Plugins/GameplayGraph/Runtime/Core/ListSlotDescriptorTemplate.cs
@@ -1,6 +1,6 @@
 using System.Collections.Concurrent;
 
-namespace Agent.Core.Gameplay
+namespace GameplayGraph
 {
     /// <summary>
     /// Provides cached <see cref="ISlotDescriptor"/> instances for list based containers.

--- a/Assets/Plugins/GameplayGraph/Runtime/Core/PropertyContainer.cs
+++ b/Assets/Plugins/GameplayGraph/Runtime/Core/PropertyContainer.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace Agent.Core.Gameplay
+namespace GameplayGraph
 {
     /// <summary>
     /// Generic base container that exposes all properties decorated with

--- a/Assets/Plugins/GameplayGraph/Runtime/Core/SlotDescriptor.cs
+++ b/Assets/Plugins/GameplayGraph/Runtime/Core/SlotDescriptor.cs
@@ -1,4 +1,4 @@
-namespace Agent.Core.Gameplay
+namespace GameplayGraph
 {
     public interface ISlotDescriptor
     {

--- a/Assets/Plugins/GameplayGraph/Runtime/Core/StatsContainer.cs
+++ b/Assets/Plugins/GameplayGraph/Runtime/Core/StatsContainer.cs
@@ -1,4 +1,4 @@
-namespace Agent.Core.Gameplay
+namespace GameplayGraph
 {
     /// <summary>
     /// Simple container of floating point stats.

--- a/Assets/Plugins/GameplayGraph/Tests/Editor/EditorDummyTests.cs
+++ b/Assets/Plugins/GameplayGraph/Tests/Editor/EditorDummyTests.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 
-namespace GameplayGraph.Tests.Editor
+namespace GameplayGraph.Tests
 {
     public class EditorDummyTests
     {

--- a/Assets/Plugins/GameplayGraph/Tests/Runtime/NodeTests.cs
+++ b/Assets/Plugins/GameplayGraph/Tests/Runtime/NodeTests.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 
-namespace GameplayGraph.Tests.Runtime
+namespace GameplayGraph.Tests
 {
     public class NodeTests
     {

--- a/Assets/Plugins/GameplayGraph/Tests/Runtime/StatsContainerTests.cs
+++ b/Assets/Plugins/GameplayGraph/Tests/Runtime/StatsContainerTests.cs
@@ -1,8 +1,8 @@
 using System;
-using Agent.Core.Gameplay;
+using GameplayGraph;
 using NUnit.Framework;
 
-namespace GameplayGraphTests
+namespace GameplayGraph.Tests
 {
     [TestFixture]
     public class StatsContainerTests


### PR DESCRIPTION
## Summary
- correct namespaces in GameplayGraph runtime code
- move editor and test scripts into `GameplayGraph.Tests`

## Testing
- `git log -1 --stat`